### PR TITLE
Allow simple string values (in addition to objects)

### DIFF
--- a/lib/DynamoKV.js
+++ b/lib/DynamoKV.js
@@ -100,6 +100,8 @@ function setKeysInOperation(operation, obj, keyFields, formattedKey) {
 DynamoKV.prototype.putOnTable = function (tableName, key, value, overwrite, callback) {
     assert(typeof key === 'string' || typeof key === 'object',
            "Key must be string or object, not " + (typeof key));
+    assert(typeof value === 'string' || typeof value === 'object',
+           "Value must be string or object, not " + (typeof key));
     assert(typeof callback === 'function', "Callback not a function. Incorrect # of arguments?");
     assert(typeof overwrite !== 'undefined', "Should set overwrite to true or false");
 
@@ -116,7 +118,7 @@ DynamoKV.prototype.putOnTable = function (tableName, key, value, overwrite, call
         Item: {}
     };
     setKeysInOperation(operation, "Item", keyFields, formattedKey);
-    operation.Item.content = { "S": JSON.stringify(value) };
+    operation.Item.content = { "S": typeof value === 'object' ? JSON.stringify(value) : value };
 
     if (!overwrite) {
         operation.Expected = {};
@@ -140,6 +142,7 @@ DynamoKV.prototype.putOnTable = function (tableName, key, value, overwrite, call
 DynamoKV.prototype.getFromTable = function (tableName, key, callback) {
     var fullTableName = this.tables.fullTableName(tableName);
     var keyFields = this.tables.getKeyFieldForTable(tableName);
+    var value = null;
 
     var formattedKey = formatKey(key);
     assertKeyFormat(keyFields, formattedKey);
@@ -169,7 +172,14 @@ DynamoKV.prototype.getFromTable = function (tableName, key, callback) {
             return;
         }
 
-        callback(err, JSON.parse(data.Item.content.S));
+        try {
+            value = JSON.parse(data.Item.content.S);
+        } catch (e) {
+            // we assume it is a string
+            value = data.Item.content.S;
+        }
+
+        callback(err, value);
     });
 };
 
@@ -280,6 +290,7 @@ DynamoKV.prototype.deleteFromTable = function (tableName, key, callback) {
     var fullTableName = this.tables.fullTableName(tableName);
     var keyFields = this.tables.getKeyFieldForTable(tableName);
     var formattedKey = formatKey(key);
+    var value = null;
 
     var operation = {
         TableName: fullTableName,
@@ -311,7 +322,14 @@ DynamoKV.prototype.deleteFromTable = function (tableName, key, callback) {
             return;
         }
 
-        callback(err, JSON.parse(data.Attributes.content.S));
+        try {
+            value = JSON.parse(data.Attributes.content.S);
+        } catch (e) {
+            // we assume it is a string
+            value = data.Attributes.content.S;
+        }
+
+        callback(err, value);
     });
 };
 


### PR DESCRIPTION
Currently when a simple string is stored as a value, dynamokv does
JSON.stringify() it. This causes extra double quotation remarks to
be added around the string value in dynamo.
